### PR TITLE
Expose ColorParseError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@
 #[macro_use]
 extern crate lazy_static;
 
-pub use self::color::color::Color;
+pub use self::color::color::{Color, ColorParseError};
 pub use self::color::named_colors::NAMED_COLORS;
 
 mod color;


### PR DESCRIPTION
The docs mention `ColorParseError` in passing, but the symbol isn't exposed to crate users. Without it, it's impossible to e.g. create chained error types where `ColorParseError` would be one of the variants.